### PR TITLE
Fix unallocated archetype policy set definition

### DIFF
--- a/lib/archetype_definitions/unallocated.alz_archetype_definition.json
+++ b/lib/archetype_definitions/unallocated.alz_archetype_definition.json
@@ -5,6 +5,8 @@
         "Enforce-ALZ-Unallocated"
     ],
     "policy_definitions": [],
-    "policy_set_definitions": [],
+    "policy_set_definitions": [
+        "Enforce-ALZ-Unallocated"
+    ],
     "role_definitions": []
 }


### PR DESCRIPTION
Add Enforce-ALZ-Unallocated to policy_set_definitions array to match policy_assignments configuration.